### PR TITLE
bugfix: resolve gammaOutput removed warning and update the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Or
 | backgroundAlpha | number        | 1                    | 0.5                                        |
 | controlsOptions | object        | -                    | see [OrbitControls Properties](https://threejs.org/docs/#examples/en/controls/OrbitControls) |
 | crossOrigin     | string        | anonymous            | anonymous/use-credentials                  |
-| gammaOutput     | boolean       | false                | true/false                                 |
+| outputEncoding     | number       | THREE.LinearEncoding                | see [WebGLRenderer OutputEncoding](https://threejs.org/docs/index.html#api/en/renderers/WebGLRenderer.outputEncoding)                                 |
 | glOptions       | object        | { antialias: true, alpha: true }  | see [WebGLRenderer Parameters](https://threejs.org/docs/index.html#api/en/renderers/WebGLRenderer) |
 
 ### events
@@ -102,6 +102,7 @@ Or
 | stl           | \<model-stl>      |
 | dae           | \<model-collada>  |
 | ply           | \<model-ply>      |
+| fbx           | \<model-fbx>      |
 | gltf(2.0)     | \<model-gltf>     |
 
 ## Browser Support

--- a/src/model-mixin.vue
+++ b/src/model-mixin.vue
@@ -24,6 +24,7 @@ import {
   PointLight,
   HemisphereLight,
   DirectionalLight,
+  LinearEncoding,
 } from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
 import { getSize, getCenter } from './util';
@@ -108,9 +109,9 @@ export default {
     crossOrigin: {
       default: 'anonymous',
     },
-    gammaOutput: {
-      type: Boolean,
-      default: false,
+    outputEncoding: {
+      type: Number,
+      default: LinearEncoding,
     },
     glOptions: {
       type: Object,
@@ -164,7 +165,7 @@ export default {
 
     this.renderer = new WebGLRenderer(options);
     this.renderer.shadowMap.enabled = true;
-    this.renderer.gammaOutput = this.gammaOutput;
+    this.renderer.outputEncoding = this.outputEncoding;
 
     this.controls = new OrbitControls(this.camera, this.$el);
     this.controls.type = 'orbit';


### PR DESCRIPTION
Resolve the warning about .gammaOutput has been removed, use outputEncoding instead.

![image](https://user-images.githubusercontent.com/22190579/80099456-13677e80-85a1-11ea-82c3-6744d8cf6d82.png)
