### PR TITLE
Loaders should use setRequestHeader

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Or
 | backgroundAlpha | number        | 1                    | 0.5                                        |
 | controlsOptions | object        | -                    | see [OrbitControls Properties](https://threejs.org/docs/#examples/en/controls/OrbitControls) |
 | crossOrigin     | string        | anonymous            | anonymous/use-credentials                  |
+| requestHeader   | object        | -                    | { 'Authorization: Bearer token' }          |
 | outputEncoding     | number       | THREE.LinearEncoding                | see [WebGLRenderer OutputEncoding](https://threejs.org/docs/index.html#api/en/renderers/WebGLRenderer.outputEncoding)                                 |
 | glOptions       | object        | { antialias: true, alpha: true }  | see [WebGLRenderer Parameters](https://threejs.org/docs/index.html#api/en/renderers/WebGLRenderer) |
 

--- a/src/model-gltf.vue
+++ b/src/model-gltf.vue
@@ -31,6 +31,7 @@ export default {
   data() {
     const loader = new GLTFLoader();
     loader.setCrossOrigin(this.crossOrigin);
+    loader.setRequestHeader(this.requestHeader);
 
     return {
       loader,

--- a/src/model-mixin.vue
+++ b/src/model-mixin.vue
@@ -109,6 +109,9 @@ export default {
     crossOrigin: {
       default: 'anonymous',
     },
+    requestHeader: {
+      default: {},
+    },
     outputEncoding: {
       type: Number,
       default: LinearEncoding,
@@ -428,6 +431,7 @@ export default {
         this.wrapper.remove(this.object);
       }
 
+      this.loader.setRequestHeader(this.requestHeader);
       this.loader.load(this.src, (...args) => {
         const object = this.getObject(...args);
 

--- a/src/model-obj.vue
+++ b/src/model-obj.vue
@@ -50,6 +50,8 @@ export default {
     const mtlLoader = new MTLLoader(manager);
 
     mtlLoader.setCrossOrigin(this.crossOrigin);
+    mtlLoader.setRequestHeader(this.requestHeader);
+    objLoader.setRequestHeader(this.requestHeader);
 
     return {
       loader: objLoader,

--- a/src/model-three.vue
+++ b/src/model-three.vue
@@ -8,6 +8,7 @@ export default {
   data() {
     const loader = new ObjectLoader();
     loader.setCrossOrigin(this.crossOrigin);
+    loader.setRequestHeader(this.requestHeader);
 
     return {
       loader,


### PR DESCRIPTION
Hi,

So basically I'd like all loaders to use a given requestHeader, for auth for example.

Its not always correctly fowarded by all subsequent/ensuing loaders inside Three.js loaders though ; but we'll get there hopefully.